### PR TITLE
Add names in logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ defer log.StopLog()
     log.SetLevel(golanglogger.ErrorLvl)
     ```
 
+    * Change logger name:
+    ```Go
+    log.SetName("Iam LOGGER!")
+    ```
+    The name is writing as a prefix (after time and before log level) of the output log message
+
     * Change buffer size (default value: 20):
     ```Go
     log.SetBufferSize(100)

--- a/golanglogger.go
+++ b/golanglogger.go
@@ -82,6 +82,10 @@ type logParam struct {
 	fileDaySize int
 	// delay for check file size function (in seconds)
 	checkFileTime int
+	// name of logger
+	name string
+	// constructed name prefix
+	namePref string
 }
 
 // logger object type
@@ -276,7 +280,17 @@ func (log *Logger) CurrentFileControl() (mbSize int, daySize int) {
 }
 
 // write logging mesage
-func writeLog(c chan logData, t time.Time, s string) {
+func writeLog(w *io.Writer, n string, d logData) error {
+	_, err := io.WriteString(*w, d.t + " -> " + n + d.msg + "\n")
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// send logging mesage
+func sendToLog(c chan logData, t time.Time, s string) {
 	c <- logData{t.Format("2006-01-02 15:04:05.000"), s, cmdWrite}
 }
 
@@ -289,7 +303,7 @@ func writeCmd(c chan<- logData, cmd loggingCmd) {
 func (log *Logger) OutDebug(msg string) {
 	// don't use mutex, the level will  changing rare and it not important if reading old or new value of it
 	if int(log.param.logLvl) <= int(DebugLvl) && log.fLogRun {
-		writeLog(log.logChan, time.Now(), "[DBG]: "+msg)
+		sendToLog(log.logChan, time.Now(), "[DBG]: "+msg)
 	}
 }
 
@@ -297,7 +311,7 @@ func (log *Logger) OutDebug(msg string) {
 func (log *Logger) OutInfo(msg string) {
 	// don't use mutex, the level will  changing rare and it not important if reading old or new value of it
 	if int(log.param.logLvl) <= int(InfoLvl) && log.fLogRun {
-		writeLog(log.logChan, time.Now(), "[INF]: "+msg)
+		sendToLog(log.logChan, time.Now(), "[INF]: "+msg)
 	}
 }
 
@@ -305,7 +319,7 @@ func (log *Logger) OutInfo(msg string) {
 func (log *Logger) OutWarning(msg string) {
 	// don't use mutex, the level will  changing rare and it not important if reading old or new value of it
 	if int(log.param.logLvl) <= int(WarningLvl) && log.fLogRun {
-		writeLog(log.logChan, time.Now(), "[WRN]: "+msg)
+		sendToLog(log.logChan, time.Now(), "[WRN]: "+msg)
 	}
 }
 
@@ -313,14 +327,14 @@ func (log *Logger) OutWarning(msg string) {
 func (log *Logger) OutError(msg string) {
 	// don't use mutex, the level will  changing rare and it not important if reading old or new value of it
 	if int(log.param.logLvl) <= int(ErrorLvl) && log.fLogRun {
-		writeLog(log.logChan, time.Now(), "[ERR]: "+msg)
+		sendToLog(log.logChan, time.Now(), "[ERR]: "+msg)
 	}
 }
 
 // always out string into log
 func (log *Logger) Out(msg string) {
 	if log.fLogRun {
-		writeLog(log.logChan, time.Now(), "[MSG]: "+msg)
+		sendToLog(log.logChan, time.Now(), "[MSG]: "+msg)
 	}
 
 }

--- a/golanglogger.go
+++ b/golanglogger.go
@@ -22,6 +22,8 @@ type Golanglogger interface {
 	Out(msg string)
 	// set log level
 	SetLevel(LoggingLevel)
+	// set name of logger for write as prefix to log
+	SetName(nameStr string)
 	// set log file control parameters
 	SetFileParam(mbSize int, daySize int)
 	// set log channel buffer size
@@ -34,6 +36,8 @@ type Golanglogger interface {
 	CurrentBufSize() (size int)
 	// get logger level
 	CurrentLevel() (lvl LoggingLevel)
+	// get logger name
+	CurrentName() (nameStr string)
 	// get logger file control parameters
 	CurrentFileControl() (mbSize int, daySize int)
 	// stopping logger

--- a/golanglogger_test.go
+++ b/golanglogger_test.go
@@ -93,6 +93,13 @@ func Test_New(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("Check %s logger creating", lType), func(t *testing.T) {
+			// test name Logger
+			loggerName := "testLogger"
+			assert.NotEqual(t, loggerName, log.CurrentName(), "Logger file name notequals")
+			log.SetName(loggerName)
+			assert.Equal(t, loggerName, log.CurrentName(), "Logger file name equals")
+
+			// test another params
 			logCon, logErr, logFile := log.CurrentOutParams()
 			lvl := log.CurrentLevel()
 			assert.True(t, logCon, "Console out enabled")

--- a/initials.go
+++ b/initials.go
@@ -16,6 +16,9 @@ const initCheckTime = 60
 // amount seconds in one day for calculating
 const secondInDay = 60 * 60 * 24
 
+// base format of time for write in log
+const timeFormat = "2006-01-02 15:04:05.000"
+
 // initializing base parameters (set parameters what not standart init values)
 func getBaseParam() *logParam {
 	return &logParam{logLvl: initLogLevel, lBuf: initLogBuffer, checkFileTime: initCheckTime, logFile: nil}

--- a/loggermass_test.go
+++ b/loggermass_test.go
@@ -1,10 +1,10 @@
 package golanglogger
 
 import (
-	"os"
-	"testing"
-	"sync"
 	"fmt"
+	"os"
+	"sync"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -19,7 +19,7 @@ func Test_OneLoggerOneFile(t *testing.T) {
 	// count of writing strings for each goroutine
 	strCnt := 10
 	// waiting goroutines
-	var grp  sync.WaitGroup
+	var grp sync.WaitGroup
 	// loger level
 	logLevel := DebugLvl
 	// logger type
@@ -27,12 +27,11 @@ func Test_OneLoggerOneFile(t *testing.T) {
 	// time for waiting writing async logger
 	tDur := time.Millisecond * 300
 	// finalize text size
-	var fSize  int64
+	var fSize int64
 	// string-text in log  size
-	var strSize  int
+	var strSize int
 
-
-	for _, v := range ([]int{1,2}){
+	for _, v := range []int{1, 2} {
 
 		// temp file
 		logFileName := uuid.NewString() + ".log"
@@ -45,15 +44,19 @@ func Test_OneLoggerOneFile(t *testing.T) {
 			log = New(logLevel, logFileName)
 			lType = "async"
 			// finalize text size for async logger
-			fSize = 228
+			fSize = int64(len("2024-06-06 22:46:08.946 -> [MSG]: Logger stopping by command \"STOP\"\n"))
+			fSize = fSize + int64(len("2024-06-06 23:06:51.876 -> [DBG]: Internal command for logger: 2\n"))
+			fSize = fSize + int64(len("2024-06-06 23:06:51.876 -> ********************************************************************************************\n"))
+			fSize = fSize + int64(len("\n\n\n"))
 		} else {
 			// creating logger
 			log = NewSync(logLevel, logFileName)
 			lType = "sync"
 			// finalize text size for sync logger
-			fSize = 170
+			fSize = int64(len("2024-06-06 22:46:08.946 -> [MSG]: Logger (sync) stopping by command \"STOP\"\n"))
+			fSize = fSize + int64(len("2024-06-06 22:46:08.946 -> [MSG]: ********************************************************************************************\n"))
+			fSize = fSize + int64(len("\n\n\n"))
 		}
-
 
 		// check logger created
 		if v == 1 {
@@ -93,19 +96,19 @@ func Test_OneLoggerOneFile(t *testing.T) {
 		fileSizeBefore := f.Size()
 
 		// starting tests
-		for i:= 0; i<cnt; i++ {
+		for i := 0; i < cnt; i++ {
 			grp.Add(1)
-			go func(k int){
-				for j:=k*strCnt;j<(k+1)*strCnt;j++ {
+			go func(k int) {
+				for j := k * strCnt; j < (k+1)*strCnt; j++ {
 					log.OutDebug(fmt.Sprintf("Logger: %3d. Value %9d", k, j))
 				}
 				grp.Done()
 			}(i)
 		}
-		// string-text in log size for current message
-		strSize = 63
 		grp.Wait()
 		log.StopLog()
+		// string-text in log size for current message
+		strSize = len("2024-06-06 22:46:08.945 -> [DBG]: ") + len(fmt.Sprintf("Logger: %3d. Value %9d", 0, 0)) + len("\n")
 
 		f, err = os.Stat(logFileName)
 		assert.NoError(t, err, "Fix starting file size")
@@ -120,9 +123,6 @@ func Test_OneLoggerOneFile(t *testing.T) {
 	}
 }
 
-
-
-
 func Test_MultyLoggerOneFile(t *testing.T) {
 	// values for testing
 
@@ -131,7 +131,7 @@ func Test_MultyLoggerOneFile(t *testing.T) {
 	// count of writing strings for each goroutine
 	strCnt := 10
 	// waiting goroutines
-	var grp  sync.WaitGroup
+	var grp sync.WaitGroup
 	// loger level
 	logLevel := DebugLvl
 	// logger type
@@ -139,12 +139,11 @@ func Test_MultyLoggerOneFile(t *testing.T) {
 	// time for waiting writing async logger
 	tDur := time.Millisecond * 300
 	// finalize text size
-	var fSize  int64
+	var fSize int64
 	// string-text in log  size
-	var strSize  int
+	var strSize int
 
-
-	for _, v := range ([]int{1,2}){
+	for _, v := range []int{1, 2} {
 
 		// temp file
 		logFileName := uuid.NewString() + ".log"
@@ -157,15 +156,19 @@ func Test_MultyLoggerOneFile(t *testing.T) {
 			log = New(logLevel, logFileName)
 			lType = "async"
 			// finalize text size for async logger
-			fSize = 228
+			fSize = int64(len("2024-06-06 22:46:08.946 -> [MSG]: Logger stopping by command \"STOP\"\n"))
+			fSize = fSize + int64(len("2024-06-06 23:06:51.876 -> [DBG]: Internal command for logger: 2\n"))
+			fSize = fSize + int64(len("2024-06-06 23:06:51.876 -> ********************************************************************************************\n"))
+			fSize = fSize + int64(len("\n\n\n"))
 		} else {
 			// creating logger
 			log = NewSync(logLevel, logFileName)
 			lType = "sync"
 			// finalize text size for sync logger
-			fSize = 170
+			fSize = int64(len("2024-06-06 22:46:08.946 -> [MSG]: Logger (sync) stopping by command \"STOP\"\n"))
+			fSize = fSize + int64(len("2024-06-06 22:46:08.946 -> [MSG]: ********************************************************************************************\n"))
+			fSize = fSize + int64(len("\n\n\n"))
 		}
-
 
 		// check logger created
 		if v == 1 {
@@ -205,19 +208,19 @@ func Test_MultyLoggerOneFile(t *testing.T) {
 		fileSizeBefore := f.Size()
 
 		// starting tests
-		for i:= 0; i<cnt; i++ {
+		for i := 0; i < cnt; i++ {
 			grp.Add(1)
-			go func(k int, l Golanglogger){
-				for j:=k*strCnt;j<(k+1)*strCnt;j++ {
+			go func(k int, l Golanglogger) {
+				for j := k * strCnt; j < (k+1)*strCnt; j++ {
 					l.OutDebug(fmt.Sprintf("Logger: %3d. Value %9d", k, j))
 				}
 				grp.Done()
 			}(i, log)
 		}
-		// string-text in log size for current message
-		strSize = 63
 		grp.Wait()
 		log.StopLog()
+		// string-text in log size for current message
+		strSize = len("2024-06-06 22:46:08.945 -> [DBG]: ") + len(fmt.Sprintf("Logger: %3d. Value %9d", 0, 0)) + len("\n")
 
 		f, err = os.Stat(logFileName)
 		assert.NoError(t, err, "Fix starting file size")


### PR DESCRIPTION
Add functions for set and get the Name of logger. The name is writing as a prefix (after time and before log level) of the output log message